### PR TITLE
[Feature] #15 - global 공통 코드 작성

### DIFF
--- a/src/main/java/com/AFFLE/server/global/BaseCode.java
+++ b/src/main/java/com/AFFLE/server/global/BaseCode.java
@@ -1,0 +1,6 @@
+package com.AFFLE.server.global;
+
+public interface BaseCode {
+    ReasonDTO getReason();
+    ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/AFFLE/server/global/BaseEntity.java
+++ b/src/main/java/com/AFFLE/server/global/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.AFFLE.server.global;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/AFFLE/server/global/BaseErrorCode.java
+++ b/src/main/java/com/AFFLE/server/global/BaseErrorCode.java
@@ -1,0 +1,6 @@
+package com.AFFLE.server.global;
+
+public interface BaseErrorCode {
+    ErrorReasonDTO getReason();
+    ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/AFFLE/server/global/ErrorReasonDTO.java
+++ b/src/main/java/com/AFFLE/server/global/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package com.AFFLE.server.global;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+    private HttpStatus httpStatus;
+
+    public boolean getIsSuccess() {
+        return isSuccess;
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/ReasonDTO.java
+++ b/src/main/java/com/AFFLE/server/global/ReasonDTO.java
@@ -1,0 +1,14 @@
+package com.AFFLE.server.global;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+    private final boolean isSuccess;
+    private final int code;
+    private final String message;
+    private HttpStatus httpStatus;
+}

--- a/src/main/java/com/AFFLE/server/global/common/ApiResponse.java
+++ b/src/main/java/com/AFFLE/server/global/common/ApiResponse.java
@@ -1,0 +1,45 @@
+package com.AFFLE.server.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.AFFLE.server.global.status.SuccessStatus;
+import com.AFFLE.server.global.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"status", "message", "code", "data"})
+public class ApiResponse<T> {
+
+    private final String status; // success 혹은 fail
+    private final String message;
+    private final int code;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    // 성공 응답
+    public static <T> ApiResponse<T> onSuccess(T data) {
+        return new ApiResponse<>(
+                "success",
+                SuccessStatus._OK.getMessage(),
+                SuccessStatus._OK.getHttpStatus().value(),
+                data
+        );
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode status, T data) {
+        return new ApiResponse<>(
+                "success",
+                status.getReasonHttpStatus().getMessage(),
+                status.getReasonHttpStatus().getHttpStatus().value(),
+                data
+        );
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> onFailure(String message, int code, T data) {
+        return new ApiResponse<>("fail", message, code, data);
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/DashboardException.java
+++ b/src/main/java/com/AFFLE/server/global/exception/DashboardException.java
@@ -1,0 +1,10 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.exception.GeneralException;
+import com.AFFLE.server.global.status.ErrorStatus;
+
+public class DashboardException extends GeneralException {
+    public DashboardException(ErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/GeneralException.java
+++ b/src/main/java/com/AFFLE/server/global/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.status.ErrorStatus;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final ErrorStatus errorStatus;
+
+    public GeneralException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/AFFLE/server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.common.ApiResponse;
+import com.AFFLE.server.global.status.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(GeneralException.class)
+  public ResponseEntity<ApiResponse<?>> handleGeneralException(GeneralException e) {
+    ErrorStatus status = e.getErrorStatus();
+    log.warn("[GeneralException] {}", status.getMessage());
+
+    return ResponseEntity
+            .status(status.getHttpStatus())
+            .body(ApiResponse.onFailure(
+                    status.getMessage(),
+                    status.getHttpStatus().value(),
+                    null
+            ));
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiResponse<?>> handleOtherException(Exception e) {
+    log.error("[UnhandledException] ", e);
+    ErrorStatus status = ErrorStatus._INTERNAL_SERVER_ERROR;
+
+    return ResponseEntity
+            .status(status.getHttpStatus())
+            .body(ApiResponse.onFailure(
+                    status.getMessage(),
+                    status.getHttpStatus().value(),
+                    null
+            ));
+  }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/ManageElderlyException.java
+++ b/src/main/java/com/AFFLE/server/global/exception/ManageElderlyException.java
@@ -1,0 +1,10 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.exception.GeneralException;
+import com.AFFLE.server.global.status.ErrorStatus;
+
+public class ManageElderlyException extends GeneralException {
+    public ManageElderlyException(ErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/ManageHeatIllnessException.java
+++ b/src/main/java/com/AFFLE/server/global/exception/ManageHeatIllnessException.java
@@ -1,0 +1,10 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.exception.GeneralException;
+import com.AFFLE.server.global.status.ErrorStatus;
+
+public class ManageHeatIllnessException extends GeneralException {
+    public ManageHeatIllnessException(ErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/ManageOnSiteException.java
+++ b/src/main/java/com/AFFLE/server/global/exception/ManageOnSiteException.java
@@ -1,0 +1,10 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.exception.GeneralException;
+import com.AFFLE.server.global.status.ErrorStatus;
+
+public class ManageOnSiteException extends GeneralException {
+    public ManageOnSiteException(ErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/exception/ManageSystemException.java
+++ b/src/main/java/com/AFFLE/server/global/exception/ManageSystemException.java
@@ -1,0 +1,10 @@
+package com.AFFLE.server.global.exception;
+
+import com.AFFLE.server.global.exception.GeneralException;
+import com.AFFLE.server.global.status.ErrorStatus;
+
+public class ManageSystemException extends GeneralException {
+    public ManageSystemException(ErrorStatus status) {
+        super(status);
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/status/ErrorStatus.java
+++ b/src/main/java/com/AFFLE/server/global/status/ErrorStatus.java
@@ -1,0 +1,53 @@
+package com.AFFLE.server.global.status;
+
+import com.AFFLE.server.global.BaseErrorCode;
+import com.AFFLE.server.global.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 공통 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "접근이 금지되었습니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+
+    // Elder 관련
+    ELDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 노인을 찾을 수 없습니다."),
+    DUPLICATED_ELDER(HttpStatus.BAD_REQUEST, "이미 존재하는 노인입니다."),
+
+    // Watch 관련
+    WATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 워치를 찾을 수 없습니다."),
+    WATCH_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 등록된 워치입니다."),
+
+    // MeterMan 관련
+    METER_MAN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 검침원을 찾을 수 없습니다."),
+    METER_MAN_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "이미 배정된 검침원입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .isSuccess(false)
+                .code(httpStatus.value())
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .isSuccess(false)
+                .code(httpStatus.value())
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/AFFLE/server/global/status/SuccessStatus.java
+++ b/src/main/java/com/AFFLE/server/global/status/SuccessStatus.java
@@ -1,0 +1,36 @@
+package com.AFFLE.server.global.status;
+
+import com.AFFLE.server.global.BaseCode;
+import com.AFFLE.server.global.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "요청에 성공하였습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .isSuccess(true)
+                .code(httpStatus.value())
+                .message(message)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .isSuccess(true)
+                .code(httpStatus.value())
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}


### PR DESCRIPTION
## Related Issue 🍀
- close #15 

<br>

## Key Changes 🔑
### Global 패키지 구조 사용 이유
  - 프로젝트 전반에서 공통적으로 사용되는 응답 포맷, 상태 코드, 예외 처리를 정리한 전역 모듈
  - 기능별 도메인(service 등)과 분리함으로써 유지보수성과 가독성을 높일 수 있음

### 패키지/파일 설명
📂 common/ApiResponse.java
<img width="443" alt="스크린샷 2025-04-10 20 18 45" src="https://github.com/user-attachments/assets/48dd0da2-ce54-4257-bd8e-bab07e3e238b" />

- 모든 API 응답을 일정한 형식으로 만들어주는 클래스
- 성공/실패 여부, 메시지, 코드, 실제 데이터 필드를 담고 있음
- 구조를 다음과 같이 하였음
    ```
  {
    "status": "success",
    "message": "요청에 성공하였습니다.",
    "code": 200,
    "data": [...]
  }
  ```
- 본인의 코드에서 다음과 같이 불러오면 됨(Controller)
  ```java
  @GetMapping("/list")
  public ApiResponse<List<String>> getList() {
      List<String> list = List.of("A", "B", "C");
      return **ApiResponse**.onSuccess(list);
  }
  ```

📂 exception/
- 전역 예외 처리와 도메인별 예외 클래스를 정의한 디렉토리임
<img width="598" alt="스크린샷 2025-04-10 20 19 00" src="https://github.com/user-attachments/assets/81184bd0-a84d-4f86-8a5d-7c3ded8c04d9" />

- 각 도메인에서 해당하는 exception을 불러와서 쓰면 됨
- 본인의 코드에서 다음과 같이 불러오면 됨(Service)
  ```java
  public Elder findById(Long id) {
      return elderRepository.findById(id)
          .orElseThrow(() -> new **ManageElderlyException**(ErrorStatus.ELDER_NOT_FOUND));
  }
  ```
- 그러면 응답 구조 중 "message"가 errorstatus에 설정한 대로 뜸
  ```
  {
    "status": "error",
    "message": "해당 노인을 찾을 수 없습니다.",
    "code": 404,
    "data": null
  }
  ```

📂 status/
- 응답에 사용되는 상태 코드와 메시지를 관리하는 공간
<img width="523" alt="스크린샷 2025-04-10 20 19 12" src="https://github.com/user-attachments/assets/76010f0b-a4e5-431a-b22e-9bec4535f0ef" />

📄 그외 파일
- BaseEntity.java
  - 모든 엔티티에 공통으로 사용되는 생성일/수정일 필드를 정의한 클래스
- 그외
  <img width="526" alt="스크린샷 2025-04-10 20 19 36" src="https://github.com/user-attachments/assets/00d54516-a3aa-479d-ab59-329fbef90925" />

## 결론적으로 개발하면서 쓸 것은 
## 1. Exception 처리 - 파일 모두 만들어뒀으므로 각자 작업할 때 불러오기만 하면 됨
## 2. ApiResponse 가져와서 그대로 쓰기 - 위 예시 참고
## 3. ErrorStatus 업데이트 - 에러가 나는 원인은 다양하므로 ErrorStatus를 관리하며 코드 작성. 작업할 때마다 ErrorStatus가 생기면 global > status > ErrorStatus.java 파일에 작성